### PR TITLE
Make InnerAsRef available to the outside world.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,5 +3,5 @@ mod json_value;
 mod parser;
 
 pub use generator::*;
-pub use json_value::{JsonValue, UnexpectedValue, InnerAsRef};
+pub use json_value::{InnerAsRef, JsonValue, UnexpectedValue};
 pub use parser::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,5 +3,5 @@ mod json_value;
 mod parser;
 
 pub use generator::*;
-pub use json_value::{JsonValue, UnexpectedValue};
+pub use json_value::{JsonValue, UnexpectedValue, InnerAsRef};
 pub use parser::*;


### PR DESCRIPTION
I am parsing complicated JSON data and therefore I am writing small helper methods like `get_something<T>(j: &JsonValue) -> T`.

For these methods it would be nice if `InnerAsRef` would be visible outside of the crate, so the Trait can be used in `where` clauses.