### PR TITLE
Add impls for `std::error::Error`

### DIFF
--- a/src/generator.rs
+++ b/src/generator.rs
@@ -1,5 +1,6 @@
 use crate::JsonValue;
 use std::collections::HashMap;
+use std::error;
 use std::fmt;
 
 #[derive(Debug)]
@@ -22,6 +23,8 @@ impl fmt::Display for JsonGenerateError {
         write!(f, "Generate error: {}", &self.msg)
     }
 }
+
+impl error::Error for JsonGenerateError {}
 
 pub type JsonGenerateResult = Result<String, JsonGenerateError>;
 

--- a/src/json_value.rs
+++ b/src/json_value.rs
@@ -1,6 +1,8 @@
 use crate::generator::{stringify, JsonGenerateResult};
 use std::collections::HashMap;
 use std::convert::TryInto;
+use std::error;
+use std::fmt;
 use std::ops::{Index, IndexMut};
 
 const NULL: () = ();
@@ -165,6 +167,14 @@ impl IndexMut<usize> for JsonValue {
 
 #[derive(Debug)]
 pub struct UnexpectedValue(JsonValue);
+
+impl fmt::Display for UnexpectedValue {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Unexpected value: {:?}", self.0)
+    }
+}
+
+impl error::Error for UnexpectedValue {}
 
 macro_rules! impl_try_into {
     ($ty:ty, $pat:pat => $val:expr) => {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,5 +1,6 @@
 use std::char;
 use std::collections::HashMap;
+use std::error;
 use std::fmt;
 use std::iter::Peekable;
 use std::str::FromStr;
@@ -28,6 +29,8 @@ impl fmt::Display for JsonParseError {
         )
     }
 }
+
+impl error::Error for JsonParseError {}
 
 pub type JsonParseResult = Result<JsonValue, JsonParseError>;
 


### PR DESCRIPTION
Add impls for `std::error::Error` for `JsonGenerateError`, `JsonParseError`, and `UnexpectedValue`.