### PR TITLE
Add support for ordered map representation of objects

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,11 @@ include = [
 [badges]
 maintenance = { status = "passively-maintained" }
 
+[features]
+ordered-map = ["dep:indexmap"]
+
 [dependencies]
+indexmap = { version = "2.4", optional = true }
 
 [dev-dependencies]
 walkdir = "2"

--- a/bench/benches/generate.rs
+++ b/bench/benches/generate.rs
@@ -1,6 +1,5 @@
 use criterion::{criterion_group, criterion_main, Criterion};
-use std::collections::HashMap;
-use tinyjson::JsonValue;
+use tinyjson::{JsonMap, JsonValue};
 
 fn generate(c: &mut Criterion) {
     c.bench_function("generate::string", |b| {
@@ -36,7 +35,7 @@ fn generate(c: &mut Criterion) {
         });
     });
     c.bench_function("generate::object", |b| {
-        let mut kv = HashMap::new();
+        let mut kv = JsonMap::new();
         kv.insert("num".into(), 123.45.into());
         kv.insert("bool".into(), true.into());
         kv.insert("str".into(), "this is test".to_string().into());

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -1,5 +1,4 @@
-use crate::JsonValue;
-use std::collections::HashMap;
+use crate::{JsonMap, JsonValue};
 use std::fmt;
 use std::io::{self, Write};
 
@@ -162,7 +161,7 @@ impl<'indent, W: Write> JsonGenerator<'indent, W> {
         self.out.write_all(b"]")
     }
 
-    fn encode_object(&mut self, m: &HashMap<String, JsonValue>) -> io::Result<()> {
+    fn encode_object(&mut self, m: &JsonMap) -> io::Result<()> {
         self.out.write_all(b"{")?;
         let mut first = true;
         for (k, v) in m {
@@ -219,7 +218,7 @@ impl<'indent, W: Write> JsonGenerator<'indent, W> {
 
     fn format_object(
         &mut self,
-        m: &HashMap<String, JsonValue>,
+        m: &JsonMap,
         indent: &str,
         level: usize,
     ) -> io::Result<()> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,8 +19,7 @@
 //! Example:
 //!
 //! ```
-//! use tinyjson::JsonValue;
-//! use std::collections::HashMap;
+//! use tinyjson::{JsonMap, JsonValue};
 //! use std::convert::TryInto;
 //!
 //! let s = r#"
@@ -39,8 +38,8 @@
 //! let parsed: JsonValue = s.parse().unwrap();
 //!
 //! // Access to inner value represented with standard containers
-//! let object: &HashMap<_, _> = parsed.get().unwrap();
-//! println!("Parsed HashMap: {:?}", object);
+//! let object: &JsonMap = parsed.get().unwrap();
+//! println!("Parsed map: {:?}", object);
 //!
 //! // Generate JSON string
 //! println!("{}", parsed.stringify().unwrap());
@@ -52,11 +51,11 @@
 //! println!("Second element of \"arr\": {:?}", elem);
 //!
 //! // Convert to inner value represented with standard containers
-//! let object: HashMap<_, _> = parsed.try_into().unwrap();
-//! println!("Converted into HashMap: {:?}", object);
+//! let object: JsonMap = parsed.try_into().unwrap();
+//! println!("Converted into map: {:?}", object);
 //!
 //! // Create JSON values from standard containers
-//! let mut m = HashMap::new();
+//! let mut m = JsonMap::new();
 //! m.insert("foo".to_string(), true.into());
 //! let mut v = JsonValue::from(m);
 //!
@@ -68,14 +67,14 @@
 //!
 //! Any JSON value is represented with [`JsonValue`] enum. Each JSON types are mapped to Rust types as follows:
 //!
-//! | JSON    | Rust                         |
-//! |---------|------------------------------|
-//! | Number  | `f64`                        |
-//! | Boolean | `bool`                       |
-//! | String  | `String`                     |
-//! | Null    | `()`                         |
-//! | Array   | `Vec<JsonValue>`             |
-//! | Object  | `HashMap<String, JsonValue>` |
+//! | JSON    | Rust                                                          |
+//! |---------|---------------------------------------------------------------|
+//! | Number  | `f64`                                                         |
+//! | Boolean | `bool`                                                        |
+//! | String  | `String`                                                      |
+//! | Null    | `()`                                                          |
+//! | Array   | `Vec<JsonValue>`                                              |
+//! | Object  | `HashMap<String, JsonValue>` or `IndexMap<String, JsonValue>` |
 //!
 //! Flexible query APIs are available to access nested elements easily without panic. See [`JsonQuery`] and
 //! [`JsonQueryMut`] for more details.
@@ -92,6 +91,6 @@ mod parser;
 mod query;
 
 pub use generator::*;
-pub use json_value::{InnerAsRef, InnerAsRefMut, JsonValue, UnexpectedValue};
+pub use json_value::{InnerAsRef, InnerAsRefMut, JsonMap, JsonValue, UnexpectedValue};
 pub use parser::*;
 pub use query::{ChildIndex, JsonQuery, JsonQueryMut};

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,10 +1,9 @@
 use std::char;
-use std::collections::HashMap;
 use std::fmt;
 use std::iter::Peekable;
 use std::str::FromStr;
 
-use crate::JsonValue;
+use crate::{JsonValue, JsonMap};
 
 /// Parse error.
 ///
@@ -172,10 +171,10 @@ impl<I: Iterator<Item = char>> JsonParser<I> {
 
         if self.peek()? == '}' {
             self.consume().unwrap();
-            return Ok(JsonValue::Object(HashMap::new()));
+            return Ok(JsonValue::Object(JsonMap::new()));
         }
 
-        let mut m = HashMap::new();
+        let mut m = JsonMap::new();
         loop {
             let key = match self.parse_any()? {
                 JsonValue::String(s) => s,

--- a/tests/generator.rs
+++ b/tests/generator.rs
@@ -1,6 +1,5 @@
-use std::collections::HashMap;
 use std::f64;
-use tinyjson::JsonValue;
+use tinyjson::{JsonMap, JsonValue};
 
 #[test]
 fn test_number() {
@@ -61,7 +60,7 @@ fn test_array() {
 
 #[test]
 fn test_object() {
-    let mut m = HashMap::new();
+    let mut m = JsonMap::new();
     m.insert("foo".to_string(), JsonValue::Number(1.0));
     m.insert("bar".to_string(), JsonValue::Boolean(false));
     m.insert("piyo".to_string(), JsonValue::Null);
@@ -72,7 +71,7 @@ fn test_object() {
     assert!(s.contains(r#""bar":false"#));
     assert!(s.contains(r#""piyo":null"#));
     assert!(s.ends_with('}'));
-    let v = JsonValue::Object(HashMap::new());
+    let v = JsonValue::Object(JsonMap::new());
     let s = v.stringify().unwrap();
     assert_eq!(&s, "{}");
 }
@@ -109,7 +108,7 @@ fn test_format_array() {
         JsonValue::Array(vec![
             JsonValue::Array(vec![
                 {
-                    let mut m = HashMap::new();
+                    let mut m = JsonMap::new();
                     m.insert("foo".to_string(), JsonValue::String("bar".to_string()));
                     JsonValue::Object(m)
                 },
@@ -146,7 +145,7 @@ fn test_format_array() {
 
 #[test]
 fn test_format_object() {
-    let mut m = HashMap::new();
+    let mut m = JsonMap::new();
     m.insert("foo".to_string(), JsonValue::Number(1.0));
     m.insert("bar".to_string(), JsonValue::Boolean(false));
     m.insert("piyo".to_string(), JsonValue::Null);
@@ -157,7 +156,7 @@ fn test_format_object() {
     assert!(s.contains(r#"  "bar": false"#));
     assert!(s.contains(r#"  "piyo": null"#));
     assert!(s.ends_with('}'));
-    let v = JsonValue::Object(HashMap::new());
+    let v = JsonValue::Object(JsonMap::new());
     let s = v.format().unwrap();
     assert_eq!(&s, "{}");
 }

--- a/tests/query.rs
+++ b/tests/query.rs
@@ -1,4 +1,3 @@
-use std::collections::HashMap;
 use tinyjson::*;
 
 #[test]
@@ -111,11 +110,11 @@ fn test_query_object_key() {
     );
     assert_eq!(
         v.query().child("a").child("d").find().unwrap(),
-        &JsonValue::Object(HashMap::new()),
+        &JsonValue::Object(JsonMap::new()),
     );
     assert_eq!(
         v.query().child("e").find().unwrap(),
-        &JsonValue::Object(HashMap::new()),
+        &JsonValue::Object(JsonMap::new()),
     );
 
     assert_eq!(
@@ -155,11 +154,11 @@ fn test_query_mut_object_key() {
     );
     assert_eq!(
         v.query_mut().child("a").child("d").find().unwrap(),
-        &mut JsonValue::Object(HashMap::new()),
+        &mut JsonValue::Object(JsonMap::new()),
     );
     assert_eq!(
         v.query_mut().child("e").find().unwrap(),
-        &mut JsonValue::Object(HashMap::new()),
+        &mut JsonValue::Object(JsonMap::new()),
     );
 
     assert_eq!(
@@ -197,7 +196,7 @@ fn test_query_mut_object_key() {
 fn test_query_value_predicate() {
     let v: JsonValue = r#"[{"a": 0, "b": 1}, 0, 1, 2]"#.parse().unwrap();
     let a: &Vec<_> = v.get().unwrap();
-    let m: &HashMap<_, _> = a[0].get().unwrap();
+    let m: &JsonMap = a[0].get().unwrap();
 
     assert_eq!(v.query().child_by(|v| v.is_object()).get(), Some(m));
     assert_eq!(v.query().child_by(|v| v.is_number()).find(), Some(&a[1]));

--- a/tests/value.rs
+++ b/tests/value.rs
@@ -1,4 +1,3 @@
-use std::collections::HashMap;
 use tinyjson::*;
 
 const STR_OK: &str = r#"
@@ -130,9 +129,9 @@ fn test_get() {
 #[test]
 fn test_get_mut() {
     let mut v = STR_OK.parse::<JsonValue>().unwrap();
-    let m: &mut HashMap<_, _> = v.get_mut().unwrap();
+    let m: &mut JsonMap = v.get_mut().unwrap();
     m.clear();
-    let m: &HashMap<_, _> = v.get().unwrap();
+    let m: &JsonMap = v.get().unwrap();
     assert!(m.is_empty());
 }
 
@@ -156,10 +155,10 @@ fn test_try_into() {
         .unwrap();
     assert_eq!(&v, &[JsonValue::Null, JsonValue::Number(3.0)]);
 
-    let mut m = HashMap::new();
+    let mut m = JsonMap::new();
     m.insert("a".to_string(), JsonValue::Null);
     m.insert("b".to_string(), JsonValue::Boolean(true));
-    let v: HashMap<_, _> = JsonValue::Object(m.clone()).try_into().unwrap();
+    let v: JsonMap = JsonValue::Object(m.clone()).try_into().unwrap();
     assert_eq!(v, m);
 }
 
@@ -182,7 +181,7 @@ fn test_is_xxx() {
     assert!(Array(vec![]).is_array());
     assert!(!Number(1.0).is_array());
 
-    assert!(Object(HashMap::new()).is_object());
+    assert!(Object(JsonMap::new()).is_object());
     assert!(!Number(1.0).is_object());
 }
 
@@ -255,7 +254,7 @@ fn test_from() {
     assert_eq!(JsonValue::from(()), JsonValue::Null);
     let v = vec![JsonValue::Number(1.0), JsonValue::Boolean(false)];
     assert_eq!(JsonValue::from(v.clone()), JsonValue::Array(v));
-    let m: HashMap<_, _> = [
+    let m: JsonMap = [
         ("a".to_string(), JsonValue::Number(1.0)),
         ("b".to_string(), JsonValue::Boolean(false)),
     ]


### PR DESCRIPTION
This adds a new feature `ordered-map` that will use an IndexMap instead of HashMap in order to preserve the order of items in an object. This features is disabled by default.

This still needs work on the documentation side of things, and perhaps any minor cleanup. I just wanted to put it up as a draft to get some feedback on whether this would be accepted at all (I understand if the consensus is that this doesn't belong in this minimal library).